### PR TITLE
update URL of the ocis-php-sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/JankariTech/ocis-sdk-php.git"
+      "url": "https://github.com/owncloud/ocis-php-sdk.git"
     }
   ],
   "require": {


### PR DESCRIPTION
the URL of the SDK has changed to a public owncloud repo