### PR TITLE
fix name of ocis sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "owncloud/ocis-sdk-php": "*@dev"
+    "owncloud/ocis-php-sdk": "*@dev"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/lib.php
+++ b/lib.php
@@ -12,10 +12,10 @@
 use core\oauth2\api as oauth2_api;
 use core\oauth2\client as oauth2_client;
 use core\oauth2\issuer as oauth2_issuer;
-use Owncloud\OcisSdkPhp\Drive;
-use Owncloud\OcisSdkPhp\DriveType;
-use Owncloud\OcisSdkPhp\Ocis;
-use Owncloud\OcisSdkPhp\OcisResource;
+use Owncloud\OcisPhpSdk\Drive;
+use Owncloud\OcisPhpSdk\DriveType;
+use Owncloud\OcisPhpSdk\Ocis;
+use Owncloud\OcisPhpSdk\OcisResource;
 use repository_ocis\issuer_management;
 
 defined('MOODLE_INTERNAL') || die();


### PR DESCRIPTION
The name of the SDK got adjusted in https://github.com/owncloud/ocis-php-sdk/pull/4 and this changes it here
