### PR TITLE
use webfinger

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,23 +75,26 @@ The moodle administrator is able to name a folder to limit every user to only be
 5. If you run ocis on any port other than `443` go to the "HTTP security" page ("Site administration" > "Server" > "HTTP security") and add the port you are using to the "cURL allowed ports list" list
 6. Go to the "OAuth 2 services" page ("Site administration" > "Server" > "OAuth 2 services")
 7. Create a new "Custom" service
-   - Choose any name you like
-     - Set "Client ID", for testing `xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69` can be used
-     - Set "Client secret", for testing `UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh` can be used
-     - Set "Service base URL" to the URL of your ocis instance. An instance with a trusted TLS certificate is required. 
-     - Set "Scopes included in a login request for offline access." to `openid offline_access email profile`
-8. Go to the "Manage repositories" page ("Site administration" > "Plugins" > "Repositories" > "Manage repositories")
-9. Set the "ownCloud Infinite Scale repository" to "Enabled and visible"
-10. Save the settings
-11. Go again into the Settings page of the "ownCloud Infinite Scale repository"
-12. Create a new repository instance
-13. Choose a name you like
-14. Select the Oauth2 service you created before
-15. Save the settings
-16. Navigate to any page where there is a file picker e.g. "My courses" > "Create course" > "Course image"
-17. "Add" a new file
-18. Select the repository you have created earlier
-19. Click "Login in to your account"
-20. Go through the login / oauth process
-21. Now you should be able to see the content of your personal space and select files from there
-
+   1. Choose any name you like
+   2. Set "Client ID", for testing `xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69` can be used
+   3. Set "Client secret", for testing `UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh` can be used
+   4. Set "Service base URL" to the URL of your ocis instance. An instance with a trusted TLS certificate is required.
+   5. Set "Scopes included in a login request for offline access." to `openid offline_access email profile`
+   6. Save the changes
+8. To use webfinger for discovery of the oCIS server that is assigned to a specific user:
+    1. Click on the "Configure endpoints" icon of the newly created service
+    2. Create a new endpoint with the name `webfinger_endpoint` and the webfinder URL e.g. `<service-base-url>/.well-known/webfinger`
+9. Go to the "Manage repositories" page ("Site administration" > "Plugins" > "Repositories" > "Manage repositories")
+10. Set the "ownCloud Infinite Scale repository" to "Enabled and visible"
+11. Save the settings
+12. Go again into the Settings page of the "ownCloud Infinite Scale repository"
+13. Create a new repository instance
+14. Choose a name you like
+15. Select the Oauth2 service you created before
+16. Save the settings
+17. Navigate to any page where there is a file picker e.g. "My courses" > "Create course" > "Course image"
+18. "Add" a new file
+19. Select the repository you have created earlier
+20. Click "Login in to your account"
+21. Go through the login / oauth process
+22. Now you should be able to see the content of your personal space and select files from there

--- a/classes/issuer_management.php
+++ b/classes/issuer_management.php
@@ -65,6 +65,17 @@ class issuer_management {
         return $endpointtoken && $endpointauth && $endpointuserinfo;
     }
 
+    public static function get_webfinger_url(\core\oauth2\issuer $issuer): string|bool {
+        $endpoints = \core\oauth2\api::get_endpoints($issuer);
+        foreach ($endpoints as $endpoint) {
+            $name = $endpoint->get('name');
+            if ($name === 'webfinger_endpoint') {
+                return $endpoint->get('url');
+            }
+        }
+        return false;
+    }
+
     /**
      * Returns the parsed url parts of an endpoint of an issuer.
      * @param string $endpointname

--- a/lang/en/repository_ocis.php
+++ b/lang/en/repository_ocis.php
@@ -35,3 +35,4 @@ $string['oauth2serviceslink'] = '<a href="{$a}" title="Link to OAuth 2 services 
 
 // Filepicker
 $string['no_personal_drive_found'] = 'No personal drive found';
+$string['webfinger_error'] = 'Could not get user-information from webfinger service.';

--- a/lib.php
+++ b/lib.php
@@ -65,13 +65,21 @@ class repository_ocis extends repository {
         if ($this->ocis === null) {
             $webfinger_url = issuer_management::get_webfinger_url($this->oauth2_issuer);
             if ($webfinger_url) {
-                $this->ocis = new Ocis($webfinger_url, $access_token->token, ['webfinger' => true]);
+                try {
+                    $this->ocis = new Ocis($webfinger_url, $access_token->token, ['webfinger' => true]);
+                } catch (\Exception $e) {
+                    throw new \moodle_exception(
+                        'webfinger_error',
+                        'repository_ocis',
+                        '',
+                        null,
+                        $e->getMessage()
+                    );
+                }
             } else {
                 $base_url = $this->oauth2_issuer->get('baseurl');
                 $this->ocis = new Ocis($base_url, $access_token->token);
             }
-
-
         } else {
             //update the token for the ocis client, just in case it changed
             $this->ocis->setAccessToken($access_token->token);

--- a/lib.php
+++ b/lib.php
@@ -63,8 +63,15 @@ class repository_ocis extends repository {
         $access_token = $this->get_user_oauth_client()->get_accesstoken();
 
         if ($this->ocis === null) {
-            $base_url = $this->oauth2_issuer->get('baseurl');
-            $this->ocis = new Ocis($base_url, $access_token->token);
+            $webfinger_url = issuer_management::get_webfinger_url($this->oauth2_issuer);
+            if ($webfinger_url) {
+                $this->ocis = new Ocis($webfinger_url, $access_token->token, ['webfinger' => true]);
+            } else {
+                $base_url = $this->oauth2_issuer->get('baseurl');
+                $this->ocis = new Ocis($base_url, $access_token->token);
+            }
+
+
         } else {
             //update the token for the ocis client, just in case it changed
             $this->ocis->setAccessToken($access_token->token);


### PR DESCRIPTION
if the oauth2 service has a `webfinger_endpoint` set use it to discover the service url responsible for the user that is authenticated with the particular token.
Needs: https://github.com/owncloud/ocis-php-sdk/pull/7