### PR TITLE
use DriveType as enum

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -96,7 +96,7 @@ class repository_ocis extends repository {
          */
         $drive = null;
         foreach ($drives as $drive) {
-            if ($drive->getType() === DriveType::PERSONAL) {
+            if ($drive->getType() === DriveType::PERSONAL->value) {
                 break;
             }
         }


### PR DESCRIPTION
the SDK changed DriveType to be an enum in https://github.com/owncloud/ocis-php-sdk/pull/6 so we cannot do a string comparison anymore but need to use `->value` (enums are basically singelton objects)
