### PR TITLE
fix no personal drive found exception

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -96,7 +96,7 @@ class repository_ocis extends repository {
          */
         $drive = null;
         foreach ($drives as $drive) {
-            if ($drive->getType() === DriveType::PERSONAL) {
+            if ($drive->getType() === DriveType::PERSONAL->value) {
                 break;
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -91,19 +91,24 @@ class repository_ocis extends repository {
 
         $ocis = $this->getOcisClient();
         $drives = $ocis->listMyDrives();
+
         /**
-         * @type ?Drive $drive
+         * @type ?Drive $personalDrive
          */
-        $drive = null;
+        $personalDrive = null;
         foreach ($drives as $drive) {
+            /**
+             * @type Drive $drive
+             */
             if ($drive->getType() === DriveType::PERSONAL->value) {
+                $personalDrive = $drive;
                 break;
             }
         }
-        if ($drive === null) {
+        if ($personalDrive === null) {
             throw new Exception(get_string('no_personal_drive_found', 'repository_ocis'));
         }
-        $resources = $drive->listResources($path);
+        $resources = $personalDrive->listResources($path);
 
         $list = [];
         /**
@@ -162,7 +167,7 @@ class repository_ocis extends repository {
             'dynload' => true,
             'nosearch' => true,
             'path' => $breadcrumb_path,
-            'manage' => $drive->getWebUrl(),
+            'manage' => $personalDrive->getWebUrl(),
             'list' => $list
         ];
     }


### PR DESCRIPTION
on top of #6

This PR fixes a tiny issue, that even if there would be a single drive found but not a personal drive, 
no Exception would be thrown because `$drive` would not be `null` anymore.

This kind of issue should never really happen, because every user should have a personal drive, but nevertheless keep the code clean
