### PR TITLE
getType returns a DriveType

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -100,7 +100,7 @@ class repository_ocis extends repository {
             /**
              * @type Drive $drive
              */
-            if ($drive->getType() === DriveType::PERSONAL->value) {
+            if ($drive->getType() === DriveType::PERSONAL) {
                 $personalDrive = $drive;
                 break;
             }


### PR DESCRIPTION
since https://github.com/owncloud/ocis-php-sdk/pull/8 `getType()` returns a `DriveType` object (an instance of the DriveType enum)
so now we can again check with `===`