### PR TITLE
docs: improve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ There are three different modes for the Moodle user to link files from oCIS to M
           docker exec  moodle-docker-webserver-1 update-ca-certificates
           ```
 3. Login to moodle as "admin"
-4. If you run oCIS on `localhost` or any local IP address go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and delete the IP address and host-name you are using from the "cURL blocked hosts list" list. E.g if you have been following the examples above and using `https://host.docker.internal:9200` as the address for oCIS, you will have to delete `127.0.0.0/8` from the list. 
+4. If you run oCIS on `localhost` or any local IP address go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and delete the IP address and host-name you are using from the "cURL blocked hosts list" list. E.g if you have been following the examples above and using `https://host.docker.internal:9200` as the address for oCIS, you will have to delete `172.16.0.0/12` from the list. 
 5. If you run oCIS on any port other than `443` go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and add the port you are using to the "cURL allowed ports list" list
 6. Go to the "OAuth 2 services" page ("Site administration" > "Server" > "OAuth 2 services")
 7. Create a new "Custom" service

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ There are three different modes for the Moodle user to link files from oCIS to M
           docker exec  moodle-docker-webserver-1 update-ca-certificates
           ```
 3. Login to moodle as "admin"
-4. If you run oCIS on `localhost` or any local IP address go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and delete the IP address and host-name you are using from the "cURL blocked hosts list" list
+4. If you run oCIS on `localhost` or any local IP address go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and delete the IP address and host-name you are using from the "cURL blocked hosts list" list. E.g if you have been following the examples above and using `https://host.docker.internal:9200` as the address for oCIS, you will have to delete `127.0.0.0/8` from the list. 
 5. If you run oCIS on any port other than `443` go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and add the port you are using to the "cURL allowed ports list" list
 6. Go to the "OAuth 2 services" page ("Site administration" > "Server" > "OAuth 2 services")
 7. Create a new "Custom" service

--- a/README.md
+++ b/README.md
@@ -28,53 +28,84 @@ There are three different modes for the Moodle user to link files from oCIS to M
    For this to work a special oCIS account needs to be connected to Moodle that will be used as a System account. If the user selects the "Controlled Link" option, the file will first be copied to a Moodle specific folder in oCIS, then shared to the System account and Moodle will access it through the System account.
 
 ## Installation
-
-1. Install [ocis](https://doc.owncloud.com/ocis/next/quickguide/quickguide.html)
-   - NOTE: if you want to run ocis on `localhost` you need to create TLS certificates, make your system trust them and start ocis with those certificates. e.g. on Debian based systems:
-     ```bash
-     openssl req -x509  -newkey rsa:2048 -keyout ocis.pem -out ocis.crt -nodes -days 365 -subj '/CN=localhost'
-     sudo cp ocis.crt /usr/local/share/ca-certificates
-     sudo update-ca-certificates
-     OCIS_INSECURE=true \
-     PROXY_HTTP_ADDR=0.0.0.0:9200 \
-     OCIS_URL=https://localhost:9200 \
-     PROXY_TRANSPORT_TLS_KEY=./ocis.pem \
-     PROXY_TRANSPORT_TLS_CERT=./ocis.crt \
-     ./ocis server
-     ```
-     :exclamation: Having set `OCIS_INSECURE=true` is not recommended for production use! :exclamation:
-2. Install moodle and this plugin
-   - Development environment with docker
-     ```bash
-     git clone https://github.com/moodle/moodle.git --branch MOODLE_402_STABLE --single-branch --depth=1
-     cd moodle/repository/
-     git clone https://github.com/owncloud/moodle-repository_ocis.git ocis
-     cd ocis
-     composer install
-     cd ../../../
-     git clone https://github.com/moodlehq/moodle-docker.git
-     cd moodle-docker
-     export MOODLE_DOCKER_WWWROOT=<path-of-your-moodle-source-code>
-     export MOODLE_DOCKER_DB=pgsql
-     export MOODLE_DOCKER_PHP_VERSION=8.1
-     cp config.docker-template.php $MOODLE_DOCKER_WWWROOT/config.php
-     bin/moodle-docker-compose up -d
-     bin/moodle-docker-wait-for-db
-     bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --agree-license --fullname="Docker moodle" --shortname="docker_moodle" --summary="Docker moodle site" --adminpass="admin" --adminemail="admin@example.com"
-     ```
-   - Other installations
-     - [Install and run moodle](https://docs.moodle.org/402/en/Installing_Moodle)
-     - copy / clone the code of the repository into the `repository/ocis` folder of your moodle installation
-     - run `composer install` inside of the `repository/ocis` folder
+1. Install moodle and this plugin
+    - Development environment with docker:
+      ```bash
+      # get moodle from git
+      git clone https://github.com/moodle/moodle.git --branch MOODLE_402_STABLE --single-branch --depth=1
+      # get and install this plugin including it's dependencies
+      cd moodle/repository/
+      git clone https://github.com/owncloud/moodle-repository_ocis.git ocis
+      cd ocis
+      composer install
+      # get docker containers for moodle developers
+      cd ../../../
+      git clone https://github.com/moodlehq/moodle-docker.git
+      cd moodle-docker
+      # some general settings for moodle
+      export MOODLE_DOCKER_WWWROOT=<path-of-your-moodle-source-code>
+      export MOODLE_DOCKER_DB=pgsql
+      export MOODLE_DOCKER_PHP_VERSION=8.1
+      cp config.docker-template.php $MOODLE_DOCKER_WWWROOT/config.php
+      # allow container to access docker host via 'host.docker.internal'
+      cat > local.yml <<'EOF'
+      services:
+        webserver:
+          extra_hosts:
+            - host.docker.internal:host-gateway
+      EOF
+      # run moodle
+      bin/moodle-docker-compose up -d
+      bin/moodle-docker-wait-for-db
+      bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --agree-license --fullname="Docker moodle" --shortname="docker_moodle" --summary="Docker moodle site" --adminpass="admin" --adminemail="admin@example.com"
+      ```
+      moodle will now be available under http://localhost:8000 
+    - Other installation methods:
+        - [Install and run moodle](https://docs.moodle.org/402/en/Installing_Moodle)
+        - copy / clone the code of the repository into the `repository/ocis` folder of your moodle installation
+        - run `composer install` inside of the `repository/ocis` folder
+2. Install [oCIS](https://doc.owncloud.com/ocis/next/quickguide/quickguide.html)
+   - NOTE: the TLS certificates of oCIS need to be trusted by the server running moodle, so if you are using self-signed certificates you need to copy them to the moodle server and make it trust them. e.g. on Debian based systems to run oCIS on `https://host.docker.internal:9200`:
+     1. create a TLS certificate
+        ```bash
+        openssl req -x509  -newkey rsa:2048 -keyout ocis.pem -out ocis.crt -nodes -days 365 -subj '/CN=host.docker.internal'
+        ```
+     2. make 'host.docker.internal' resolve to the IP 127.0.0.1 on the docker host machine
+        ```bash
+        sudo sh -c "echo '127.0.0.1 host.docker.internal' >> /etc/hosts"
+        ```
+     3. run oCIS using this certificate: 
+        ```bash
+        OCIS_INSECURE=true \
+        PROXY_HTTP_ADDR=0.0.0.0:9200 \
+        OCIS_URL=https://host.docker.internal:9200 \
+        PROXY_TRANSPORT_TLS_KEY=./ocis.pem \
+        PROXY_TRANSPORT_TLS_CERT=./ocis.crt \
+        ./ocis server
+        ```
+        :exclamation: Having set `OCIS_INSECURE=true` is not recommended for production use! :exclamation:
+     4. copy the certificate file to the store of the oCIS server and make the system trust it
+        - if oCIS runs on the same server as moodle:
+          ```bash
+          sudo cp ocis.crt /usr/local/share/ca-certificates
+          sudo update-ca-certificates
+          ```
+        - if moodle runs in the development docker container from point 1:
+          ```bash
+          docker cp ocis.crt moodle-docker-webserver-1:/usr/local/share/ca-certificates/
+          docker exec  moodle-docker-webserver-1 update-ca-certificates
+          ```
 3. Login to moodle as "admin"
-4. If you run ocis on `localhost` or any local IP address go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and delete the IP address and host-name you are using from the "cURL blocked hosts list" list
-5. If you run ocis on any port other than `443` go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and add the port you are using to the "cURL allowed ports list" list
+4. If you run oCIS on `localhost` or any local IP address go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and delete the IP address and host-name you are using from the "cURL blocked hosts list" list
+5. If you run oCIS on any port other than `443` go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and add the port you are using to the "cURL allowed ports list" list
 6. Go to the "OAuth 2 services" page ("Site administration" > "Server" > "OAuth 2 services")
 7. Create a new "Custom" service
    1. Choose any name you like
-   2. Set "Client ID", for testing `xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69` can be used
-   3. Set "Client secret", for testing `UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh` can be used
-   4. Set "Service base URL" to the URL of your ocis instance. An instance with a trusted TLS certificate is required.
+   2. Set "Client ID".
+      If moodle runs on `localhost` the ID `xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69` can be used for testing, else another client need to be set up in the [oCIS IDP](https://owncloud.dev/services/idp/configuration/)
+   3. Set "Client secret"
+      If moodle runs on `localhost` the secret `UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh` can be used for testing, else another client need to be set up in the [oCIS IDP](https://owncloud.dev/services/idp/configuration/)
+   4. Set "Service base URL" to the URL of your oCIS instance. An instance with a trusted TLS certificate is required, e.g. `https://host.docker.internal:9200`
    5. Set "Scopes included in a login request for offline access." to `openid offline_access email profile`
    6. Save the changes
 8. To use webfinger for discovery of the oCIS server that is assigned to a specific user:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There are three different modes for the Moodle user to link files from oCIS to M
           ```
 3. Login to moodle as "admin"
 4. If you run oCIS on `localhost` or any local IP address go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and delete the IP address and host-name you are using from the "cURL blocked hosts list" list. E.g if you have been following the examples above and using `https://host.docker.internal:9200` as the address for oCIS, you will have to delete `172.16.0.0/12` from the list. 
-5. If you run oCIS on any port other than `443` go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and add the port you are using to the "cURL allowed ports list" list
+5. If you run oCIS on any port other than `443` go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and add the port you are using to the "cURL allowed ports list" list. E.g. if you have been following the examples above add `9200` to the list.
 6. Go to the "OAuth 2 services" page ("Site administration" > "Server" > "OAuth 2 services")
 7. Create a new "Custom" service
    1. Choose any name you like


### PR DESCRIPTION
Improve installation examples, because:
- ocis certificate need to be trusted by the server that runs moodle
- the openID connect client in the oCIS IDP needs to have a  redirect_uri configured that correspond to the URI of moodle