### PR TITLE
create OAuth2 services and repository instance during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There are three different modes for the Moodle user to link files from oCIS to M
 4. Login to moodle as "admin"
 5. If you run oCIS on `localhost` or any local IP address go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and delete the IP address and host-name you are using from the "cURL blocked hosts list" list. E.g if you have been following the examples above and using `https://host.docker.internal:9200` as the address for oCIS, you will have to delete `172.16.0.0/12` from the list. 
 6. If you run oCIS on any port other than `443` go to the "HTTP security" page ("Site administration" > "General" > "Security" > "HTTP security") and add the port you are using to the "cURL allowed ports list" list. E.g. if you have been following the examples above add `9200` to the list.
-7. Go to the "OAuth 2 services" page ("Site administration" > "Server" > "OAuth 2 services")
+7. Go to the "OAuth 2 services" page ("Site administration" > "Server" >"Server" > "OAuth 2 services")
 8. Create a new "Custom" service
    1. Choose any name you like
    2. Set "Client ID".

--- a/db/install.php
+++ b/db/install.php
@@ -1,0 +1,76 @@
+<?php
+// This file is part of the ocis repository for Moodle - http://moodle.org/
+//
+// The ocis repository for Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The ocis repository for Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
+//
+/**
+ * Installation function for the oCIS repository plugin.
+ *
+ * @package    repository_ocis
+ * @copyright  2023 ownCloud GmbH
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+function xmldb_repository_ocis_install() {
+    global $CFG, $USER;
+    $result = true;
+    require_once($CFG->dirroot . '/repository/lib.php');
+    $ocisplugin = new repository_type('ocis', [], true);
+    if (!$id = $ocisplugin->create(true)) {
+        $result = false;
+    }
+    if (strtolower(getenv('MOODLE_DISABLE_CURL_SECURITY')) === 'true') {
+        set_config('curlsecurityblockedhosts', '');
+        set_config('curlsecurityallowedport', '');
+    }
+
+    $ocisurl = getenv('MOODLE_OCIS_URL');
+    $ocislogourl = getenv('MOODLE_OCIS_LOGO_URL');
+    $clientid = getenv('MOODLE_OCIS_CLIENT_ID');
+    $clientsecret = getenv('MOODLE_OCIS_CLIENT_SECRET');
+    if ($ocisurl !== false && $clientsecret !== false && $clientid !== false) {
+        $issuerdata = new \stdClass();
+        $issuerdata->name = "oCIS";
+        $issuerdata->clientid = $clientid;
+        $issuerdata->clientsecret = $clientsecret;
+        $issuerdata->loginscopes = "openid profile email";
+        $issuerdata->loginscopesoffline = "openid profile email offline_access";
+        $issuerdata->baseurl = $ocisurl;
+        if (!$ocislogourl) {
+            $issuerdata->image = $ocisurl . '/themes/owncloud/assets/logo_dark.svg';
+        } else {
+            $issuerdata->image = $ocislogourl;
+        }
+
+
+        $issuer = core\oauth2\api::create_issuer($issuerdata);
+        $result = $issuer->is_valid();
+        if (!$result) {
+            return $result;
+        }
+        $repo = repository::create(
+            'ocis',
+            $USER->id,
+            context_system::instance(),
+            [
+                'name' => 'oCIS',
+                'issuerid' => $issuer->get('id'),
+            ]
+        );
+        if ($repo === null) {
+            $result = false;
+        }
+    }
+    return $result;
+}

--- a/lib.php
+++ b/lib.php
@@ -73,6 +73,10 @@ class repository_ocis extends repository {
      * @param array $options
      */
     public function __construct($repositoryid, $context = SYSCONTEXTID, $options = []) {
+        if (strtolower(getenv('MOODLE_DISABLE_CURL_SECURITY')) === 'true') {
+            set_config('curlsecurityblockedhosts', '');
+            set_config('curlsecurityallowedport', '');
+        }
         parent::__construct($repositoryid, $context, $options);
         // Issuer from repository instance config.
         $issuerid = $this->get_option('issuerid');


### PR DESCRIPTION
This changes should help to run automated tests
1. the plugin is enabled during installation
2. when installing moodle and the env variable `MOODLE_DISABLE_CURL_SECURITY="true"` is set all curl security checks will be disabled for the installation
3. when running the plugin the first time and the env variable `MOODLE_DISABLE_CURL_SECURITY="true"` is set all curl security checks will be deleted permanently
4. when installing moodle and the env variables  `MOODLE_OCIS_URL`, `MOODLE_OCIS_CLIENT_ID` & `MOODLE_OCIS_CLIENT_SECRET` are set an OAuth 2 services and a repository instance is created automatically

The docker example in the `README.md` is adjusted in a way that this all will happen when following it, so after all the steps tests can rely on the basic setup of the plugin.