### PR TITLE
adding lang string for 'no_right_issuers'

### DIFF
--- a/lang/en/repository_ocis.php
+++ b/lang/en/repository_ocis.php
@@ -29,6 +29,7 @@ $string['configplugin'] = 'ownCloud Infinite Scale repository configuration';
 // Settings.
 $string['chooseissuer'] = 'Issuer';
 $string['right_issuers'] = 'The following issuers implement the required endpoints: <br> {$a}';
+$string['no_right_issuers'] = 'None of the existing issuers implement all required endpoints. Please register an appropriate issuer.';
 $string['chooseissuer_help'] = 'To add a new issuer, go to Site administration / Server / OAuth 2 services.';
 $string['oauth2serviceslink'] = '<a href="{$a}" title="Link to OAuth 2 services configuration">OAuth 2 services configuration</a>';
 


### PR DESCRIPTION
When there is no valid issuer the propper error message needs to be shown, but the language string was not defined.

The string is used in https://github.com/owncloud/moodle-repository_ocis/blob/c91975267f4bd00700266eb272de6db588cdadfd/lib.php#L269 
