### PR TITLE
implement null privacy provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of the ocis repository for Moodle - http://moodle.org/
+//
+// The ocis repository for Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The ocis repository for Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+/**
+ * Privacy provider.
+ *
+ * @package    repository_ocis
+ * @copyright  2018 Nina Herrmann (Learnweb, University of Münster)
+ * @copyright  2023 ownCloud GmbH
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace repository_ocis\privacy;
+
+/**
+ * Privacy provider implementing null_provider.
+ *
+ * @package    repository_ocis
+ * @copyright  2018 Nina Herrmann (Learnweb, University of Münster)
+ * @copyright  2023 ownCloud GmbH
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/repository_ocis.php
+++ b/lang/en/repository_ocis.php
@@ -35,7 +35,7 @@ $string['right_issuers'] = 'The following issuers implement the required endpoin
 $string['no_right_issuers'] = 'None of the existing issuers implement all required endpoints. Please register an appropriate issuer.';
 $string['chooseissuer_help'] = 'To add a new issuer, go to Site administration / Server / OAuth 2 services.';
 $string['oauth2serviceslink'] = '<a href="{$a}" title="Link to OAuth 2 services configuration">OAuth 2 services configuration</a>';
-
+$string['privacy:metadata'] = 'The ownCloud Infinite Scale repository plugin neither stores any personal data nor transmits user data to the remote system.';
 
 // Filepicker.
 $string['no_personal_drive_found'] = 'No personal drive found';


### PR DESCRIPTION
The plugin does not store nor transmit any personal data, so to be compliant to the [privacy requirements of moodle](https://moodledev.io/docs/apis/subsystems/privacy) it should be enough to have the `null` provider.
See #25 for details and discussion

fixes #25

CC @PhMemmel
