### PR TITLE
adapt license header

### DIFF
--- a/classes/configuration_exception.php
+++ b/classes/configuration_exception.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,6 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
+
 /**
  * Exception for when client configuration data is missing.
  *

--- a/classes/issuer_management.php
+++ b/classes/issuer_management.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
 
 /**
  * Provide static functions for creating and validating issuers.

--- a/classes/ocis_manager.php
+++ b/classes/ocis_manager.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
 
 namespace repository_ocis;
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
-
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
 
 /**
  * Privacy provider.

--- a/db/access.php
+++ b/db/access.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,6 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
+
 /**
  * Plugin capabilities.
  *

--- a/db/install.php
+++ b/db/install.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,6 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
+
 /**
  * Installation function for the oCIS repository plugin.
  *

--- a/lang/en/repository_ocis.php
+++ b/lang/en/repository_ocis.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,6 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
+
 /**
  * Language strings' definition for ocis repository.
  *

--- a/lib.php
+++ b/lib.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
 
 /**
  * oCIS repository plugin library.

--- a/version.php
+++ b/version.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of the ocis repository for Moodle - http://moodle.org/
+// This file is part of the ownCloud Infinite Scale for moodle Repository https://github.com/owncloud/moodle-repository_ocis
 //
 // The ocis repository for Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,6 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the ocis repository for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
+// ownCloud Infinite Scale for moodle Repository is built with the contributions of:
+// - Staatsinstitut für Schulqualität und Bildungsforschung
+// - JankariTech
+// - ownCloud - a Kiteworks company.
+
 /**
  * Version metadata for the repository_ocis plugin.
  *


### PR DESCRIPTION
make license header display all needed information

moodle style is stict about the length of the lines and the content of the third line, that's why I've placed the contributors at the bottom.
Alternatively we could add the contributors into the PHPDoc part with `@author` or `@copyright` but that does not work so well, because the author is more of a person and not all contributor (orgs) have copyright

fixes #31
