### PR TITLE
allow to set icons for every drive type

### DIFF
--- a/classes/ocis_manager.php
+++ b/classes/ocis_manager.php
@@ -53,19 +53,28 @@ class ocis_manager {
     private string $path;
     private ?Drive $drive = null;
     private ?Ocis $ocis = null;
+    private ?string $personaldriveiconurl;
+    private ?string $sharesiconurl;
+    private ?string $projectdriveiconurl;
 
     public function __construct(
         oauth2_client $oauth2client,
         oauth2_issuer $oauth2issuer,
         bool $showpersonaldrive,
         bool $showshares,
-        bool $showprojectdrives
+        bool $showprojectdrives,
+        ?string $personaldriveiconurl,
+        ?string $sharesiconurl,
+        ?string $projectdriveiconurl
     ) {
         $this->oauth2client = $oauth2client;
         $this->oauth2issuer = $oauth2issuer;
         $this->showpersonaldrive = $showpersonaldrive;
         $this->showshares = $showshares;
         $this->showprojectdrives = $showprojectdrives;
+        $this->personaldriveiconurl = $personaldriveiconurl;
+        $this->sharesiconurl = $sharesiconurl;
+        $this->projectdriveiconurl = $projectdriveiconurl;
     }
 
     private function get_drive_id(): string {
@@ -208,10 +217,16 @@ class ocis_manager {
         }
         if ($drive->getType() === DriveType::PERSONAL) {
             $drivetitle = get_string('personal_drive', 'repository_ocis');
+            $thumbnail = $this->personaldriveiconurl;
+            $icon = $this->personaldriveiconurl;
         } else if ($drive->getType() === DriveType::VIRTUAL) {
             $drivetitle = get_string('shares_drive', 'repository_ocis');
+            $thumbnail = $this->sharesiconurl;
+            $icon = $this->sharesiconurl;
         } else {
             $drivetitle = $drive->getName();
+            $thumbnail = $this->projectdriveiconurl;
+            $icon = $this->projectdriveiconurl;
         }
         try {
             $size = (int)$drive->getQuota()->getUsed();
@@ -225,13 +240,18 @@ class ocis_manager {
             $datemodified = "";
         }
 
+        if ($thumbnail === null || trim($thumbnail) === '') {
+            $thumbnail = $OUTPUT->image_url(file_folder_icon(90))->out(false);
+            $icon = $OUTPUT->image_url(file_folder_icon(24))->out(false);
+        }
         return [
             'title' => $drivetitle,
             'datemodified' => $datemodified,
             'source' => $drive->getId(),
             'children' => [],
             'path' => $drive->getId(),
-            'thumbnail' => $OUTPUT->image_url(file_folder_icon(90))->out(false),
+            'thumbnail' => $thumbnail,
+            'icon' => $icon,
             'size' => $size,
         ];
     }

--- a/lang/en/repository_ocis.php
+++ b/lang/en/repository_ocis.php
@@ -39,6 +39,9 @@ $string['privacy:metadata'] = 'The ownCloud Infinite Scale repository plugin nei
 $string['show_personal_drive'] = 'Show Personal Drive';
 $string['show_shares'] = 'Show Shares';
 $string['show_project_drives'] = 'Show Project Drives';
+$string['personal_drive_icon_url'] = 'Icon URL for Personal Drive';
+$string['shares_icon_url'] = 'Icon URL for Shares';
+$string['project_drives_icon_url'] = 'Icon URL for Project Drives';
 
 
 // Filepicker.

--- a/lib.php
+++ b/lib.php
@@ -117,7 +117,10 @@ class repository_ocis extends repository {
                 $this->oauth2issuer,
                 ($this->get_option('show_personal_drive') === "1"),
                 ($this->get_option('show_shares') === "1"),
-                ($this->get_option('show_project_drives') === "1")
+                ($this->get_option('show_project_drives') === "1"),
+                $this->get_option('personal_drive_icon_url'),
+                $this->get_option('shares_icon_url'),
+                $this->get_option('project_drives_icon_url')
             );
         }
 
@@ -225,6 +228,27 @@ class repository_ocis extends repository {
         );
 
         $mform->setDefault('show_project_drives', 1);
+
+        $mform->addElement(
+            'text',
+            'personal_drive_icon_url',
+            get_string('personal_drive_icon_url', 'repository_ocis')
+        );
+        $mform->setType('personal_drive_icon_url', PARAM_TEXT);
+
+        $mform->addElement(
+            'text',
+            'shares_icon_url',
+            get_string('shares_icon_url', 'repository_ocis')
+        );
+        $mform->setType('shares_icon_url', PARAM_TEXT);
+
+        $mform->addElement(
+            'text',
+            'project_drives_icon_url',
+            get_string('project_drives_icon_url', 'repository_ocis')
+        );
+        $mform->setType('project_drives_icon_url', PARAM_TEXT);
     }
 
     /**
@@ -335,7 +359,8 @@ class repository_ocis extends repository {
     public static function get_instance_option_names() {
         return ['issuerid', 'controlledlinkfoldername',
             'defaultreturntype', 'supportedreturntypes',
-            'show_personal_drive', 'show_shares', 'show_project_drives'];
+            'show_personal_drive', 'show_shares', 'show_project_drives',
+            'personal_drive_icon_url', 'shares_icon_url', 'project_drives_icon_url'];
     }
 
     /**


### PR DESCRIPTION
on top of  #51, so review only last commit

This allows to have specific icons for every type of drive (personal, project, space)

![grafik](https://github.com/owncloud/moodle-repository_ocis/assets/2425577/67bc17be-891c-41ab-b21e-51eed7131eae)
![grafik](https://github.com/owncloud/moodle-repository_ocis/assets/2425577/20580bcd-9503-427c-b8ee-17cc6827bf60)
![grafik](https://github.com/owncloud/moodle-repository_ocis/assets/2425577/9bc1da6f-bf4f-4b8b-84ad-e5f5a81ace70)

If one or multiple types don't have an icon set, the default folder icon will be used:
![grafik](https://github.com/owncloud/moodle-repository_ocis/assets/2425577/7813d93c-69d4-4335-b358-d131b71d9c5f)

relative path of an icon can be used e.g.:
`/icons/shares.png` will use the URL relative to the webserver root.

fixes #53 