### PR TITLE
Improve php docs

### DIFF
--- a/classes/ocis_manager.php
+++ b/classes/ocis_manager.php
@@ -52,7 +52,7 @@ class ocis_manager {
     private oauth2_issuer $oauth2issuer;
     /**
      * String containing the drive_id and the current path. The drive_id is separated from the path by a colon ":".
-     * @var string
+     * @var string|null
      */
     private ?string $driveidandpath = null;
     /**

--- a/db/install.php
+++ b/db/install.php
@@ -27,7 +27,7 @@
  * If the env. variables MOODLE_OCIS_URL, MOODLE_OCIS_CLIENT_ID & MOODLE_OCIS_CLIENT_SECRET are set
  * a new oauth2 issuer and a repository instance will be created
  *
- * The env. variable MOODLE_DISABLE_CURL_SECURITY ca be used to disable curl security settings, this can be useful
+ * The env. variable MOODLE_DISABLE_CURL_SECURITY can be used to disable curl security settings, this can be useful
  * to test on localhost and similar environments.
  *
  * @return bool Returns true if the installation is successful, false otherwise.

--- a/db/install.php
+++ b/db/install.php
@@ -22,6 +22,16 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+/**
+ * Enables the OCIS repository plugin.
+ * If the env. variables MOODLE_OCIS_URL, MOODLE_OCIS_CLIENT_ID & MOODLE_OCIS_CLIENT_SECRET are set
+ * a new oauth2 issuer and a repository instance will be created
+ *
+ * The env. variable MOODLE_DISABLE_CURL_SECURITY ca be used to disable curl security settings, this can be useful
+ * to test on localhost and similar environments.
+ *
+ * @return bool Returns true if the installation is successful, false otherwise.
+ */
 function xmldb_repository_ocis_install() {
     global $CFG, $USER;
     $result = true;

--- a/lib.php
+++ b/lib.php
@@ -426,14 +426,4 @@ class repository_ocis extends repository {
         }
         return ['path' => $localpath, 'url' => $fileid];
     }
-
-    private function get_drive_id_regex(): string {
-        return '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}\\$' .
-               '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}';
-    }
-    private function is_valid_drive_id(string $path) {
-        $regex = '/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}\\$' .
-                 '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/';
-        return preg_match($regex, $path) === 1;
-    }
 }


### PR DESCRIPTION
fix all PHPdoc issues reported by The Moodle [PHPdoc checker](https://github.com/moodlehq/moodle-local_moodlecheck)

Some entries are pretty useless, e.g. the `@params` in the PHPDocs if the parameter type is already defined, but that's what is required.