### PR TITLE
use service URL as managed URL

### DIFF
--- a/classes/ocis_manager.php
+++ b/classes/ocis_manager.php
@@ -626,7 +626,7 @@ class ocis_manager {
         if (!$this->is_root()) {
             return $this->get_drive()->getWebUrl();
         } else {
-            return $this->oauth2issuer->get('baseurl');
+            return $this->get_ocis_client()->getServiceUrl();
         }
     }
 }


### PR DESCRIPTION
the baseurl might be wrong, because its the url of the oauth service not of the webUI

fixes #50