### PR TITLE
Remove moodle's core security settings from source code

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -48,7 +48,6 @@ MOODLE_ENV = {
     "MOODLE_DBPASS": "moodle",
     "MOODLE_DATAROOT": "/var/www/moodledata",
     "MOODLE_OCIS_URL": "https://ocis:9200",
-    "MOODLE_DISABLE_CURL_SECURITY": "true",
     "MOODLE_OCIS_CLIENT_ID": "moodle-ocis-integration",
     "MOODLE_OCIS_CLIENT_SECRET": "UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh",
     "BROWSER": "chrome",

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ There are three different modes for the Moodle user to link files from oCIS to M
       export MOODLE_DOCKER_DB=pgsql
       export MOODLE_DOCKER_PHP_VERSION=8.1
       cp config.docker-template.php $MOODLE_DOCKER_WWWROOT/config.php
+      # disable some security settings, that would block access to non standard ports and local addresses
+      # !DON'T DO THAT FOR PRODUCTION INSTALLATIONS!
+      sed -i "s|require_once(__DIR__ . '/lib/setup.php');|\$CFG->curlsecurityblockedhosts = '';\n\$CFG->curlsecurityallowedport = '';\n\$CFG->behat_extraallowedsettings = ['curlsecurityblockedhosts', 'curlsecurityallowedport'];\nrequire_once(__DIR__ . '/lib/setup.php');|" $MOODLE_DOCKER_WWWROOT/config.php
       # allow container to access docker host via 'host.docker.internal'
       cat > local.yml <<'EOF'
       services:
@@ -73,7 +76,6 @@ There are three different modes for the Moodle user to link files from oCIS to M
           extra_hosts:
             - host.docker.internal:host-gateway
           environment:
-            MOODLE_DISABLE_CURL_SECURITY: "true" # optional, but useful for testing on localhost or host.docker.internal
             MOODLE_OCIS_URL: "https://host.docker.internal:9200" # optional, used to create OAuth 2 services and repository instance during installation
             MOODLE_OCIS_CLIENT_ID: "xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69"  # optional, used to create OAuth 2 services and repository instance during installation
             MOODLE_OCIS_CLIENT_SECRET: "UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh" # optional, used to create OAuth 2 services and repository instance during installation
@@ -152,7 +154,6 @@ There are three different modes for the Moodle user to link files from oCIS to M
 
 To reduce the setup steps specially when doing development and running automated tests these environment variables can be set to auto-provision the plugin:
 
-- `MOODLE_DISABLE_CURL_SECURITY="true"` to disable and delete all curl security checks, useful for testing on localhost or host.docker.internal
 - `MOODLE_OCIS_URL`, `MOODLE_OCIS_CLIENT_ID`, `MOODLE_OCIS_CLIENT_SECRET`, `MOODLE_OCIS_LOGO_URL` to create OAuth 2 services and repository instance during installation. Note: the auto-provisioning will be triggered only if all of `MOODLE_OCIS_URL`, `MOODLE_OCIS_CLIENT_ID`, `MOODLE_OCIS_CLIENT_SECRET` variables are set.
 
 ### Run tests

--- a/db/install.php
+++ b/db/install.php
@@ -45,10 +45,6 @@ function xmldb_repository_ocis_install() {
     if (!$id = $ocisplugin->create(true)) {
         $result = false;
     }
-    if (strtolower(getenv('MOODLE_DISABLE_CURL_SECURITY')) === 'true') {
-        set_config('curlsecurityblockedhosts', '');
-        set_config('curlsecurityallowedport', '');
-    }
 
     $ocisurl = getenv('MOODLE_OCIS_URL');
     $ocislogourl = getenv('MOODLE_OCIS_LOGO_URL');

--- a/db/install.php
+++ b/db/install.php
@@ -32,8 +32,6 @@
  * If the env. variables MOODLE_OCIS_URL, MOODLE_OCIS_CLIENT_ID & MOODLE_OCIS_CLIENT_SECRET are set
  * a new oauth2 issuer and a repository instance will be created
  *
- * The env. variable MOODLE_DISABLE_CURL_SECURITY can be used to disable curl security settings, this can be useful
- * to test on localhost and similar environments.
  *
  * @return bool Returns true if the installation is successful, false otherwise.
  */

--- a/lib.php
+++ b/lib.php
@@ -83,10 +83,6 @@ class repository_ocis extends repository {
      * @throws coding_exception|dml_exception
      */
     public function __construct($repositoryid, $context = SYSCONTEXTID, $options = []) {
-        if (strtolower(getenv('MOODLE_DISABLE_CURL_SECURITY')) === 'true') {
-            set_config('curlsecurityblockedhosts', '');
-            set_config('curlsecurityallowedport', '');
-        }
         parent::__construct($repositoryid, $context, $options);
         // Issuer from repository instance config.
         $issuerid = $this->get_option('issuerid');

--- a/tests/drone/config.php
+++ b/tests/drone/config.php
@@ -56,4 +56,8 @@ $CFG->behat_profiles = [
         ],
     ],
 ];
+$CFG->curlsecurityblockedhosts = '';
+$CFG->curlsecurityallowedport = '';
+$CFG->behat_extraallowedsettings = array('curlsecurityblockedhosts', 'curlsecurityallowedport');
+
 require_once(__DIR__ . '/lib/setup.php');

--- a/tests/drone/config.php
+++ b/tests/drone/config.php
@@ -58,6 +58,6 @@ $CFG->behat_profiles = [
 ];
 $CFG->curlsecurityblockedhosts = '';
 $CFG->curlsecurityallowedport = '';
-$CFG->behat_extraallowedsettings = array('curlsecurityblockedhosts', 'curlsecurityallowedport');
+$CFG->behat_extraallowedsettings = ['curlsecurityblockedhosts', 'curlsecurityallowedport'];
 
 require_once(__DIR__ . '/lib/setup.php');

--- a/tests/local.example.yml
+++ b/tests/local.example.yml
@@ -11,7 +11,6 @@ services:
       - host.docker.internal:host-gateway
       - moodle.webserver:host-gateway
     environment:
-      MOODLE_DISABLE_CURL_SECURITY: "true" # optional, but useful for testing on localhost or host.docker.internal
       MOODLE_OCIS_URL: "https://host.docker.internal:9200" # optional, used to create OAuth 2 services and repository instance during installation
       OCIS_ADMIN_PASSWORD: admin
       OCIS_ADMIN_USERNAME: admin


### PR DESCRIPTION
## Description
Previously, the source code included Moodle's core security configurations to facilitate automatic provisioning of port and URL blocking/allowing. However, adhering to Moodle standards, this practice is not permissible. Thus, exploring alternative methods to clear blocked URLs and ports for testing purposes:
```
    if (strtolower(getenv('MOODLE_DISABLE_CURL_SECURITY')) === 'true') {
        set_config('curlsecurityblockedhosts', '');
        set_config('curlsecurityallowedport', '');
    }
```

## Related issue 
- https://github.com/owncloud/moodle-repository_ocis/issues/94