### PR TITLE
updating test step for enabling share sync in stable branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -171,7 +171,7 @@ def behatTest():
             "depends_on": [],
             "steps": generateSSLCert() + apacheService() + waitForService("apache", 443) + runOcis(branch) +
                      waitForService("ocis", 9200) + waitForService("postgresql", 5432) +
-                     waitForService("selenium", 4444) + setupMoodle() + runBehatUITest(branch),
+                     waitForService("selenium", 4444) + setupMoodle() + runBehatUITest(),
             "volumes": [
                 {
                     "name": "www-moodle",
@@ -374,11 +374,7 @@ def seleniumService():
         },
     ]
 
-def runBehatUITest(branch):
-    if branch == "master":
-        tags = "@ocis"
-    else:
-        tags = "@ocis &&~@skipOnStable"
+def runBehatUITest():
     return [
         {
             "name": "behat-UI-test",
@@ -387,7 +383,7 @@ def runBehatUITest(branch):
             "commands": [
                 "update-ca-certificates",
                 "cd /var/www/html/moodle",
-                'vendor/bin/behat --config /var/www/behatdata/behatrun/behat/behat.yml --tags="%s"' % tags,
+                'vendor/bin/behat --config /var/www/behatdata/behatrun/behat/behat.yml --tags="@ocis"',
             ],
             "volumes": [
                 {

--- a/tests/behat/graph_helper.php
+++ b/tests/behat/graph_helper.php
@@ -296,6 +296,7 @@ class graph_helper {
     public function enable_share_sync(string $user, string $share, string $offeredby, string $space): array {
         $itemid = $this->get_resource_id($offeredby, $share, $space);
         $body = [
+            "name" => $share,
             "remoteItem" => [
                 "id" => $itemid,
             ],

--- a/tests/behat/uploadFileToMoodle.feature
+++ b/tests/behat/uploadFileToMoodle.feature
@@ -104,7 +104,6 @@ Feature: upload the resource in oCIS to moodle
     And I should see "Shares"
     And I should see "ProjectMoodle"
 
-  @skipOnStable @ocis-issue-8961
   Scenario: enable/disable sync of shared resource shared from Personal Space
     Given user "Brian" has been created with default attributes
     And user "Brian" has uploaded a file inside space "Personal" with content "some content" to "/testfile.txt"


### PR DESCRIPTION
Currently, we've skipped the test for enabling share sync while integrating ocis with stable 5.0 branch. It can be worked out by updating the body of the share sync request and include `name` of the share. This value is optional for master branch. 