### PR TITLE
ci: pin all GitHub Actions to SHA for org security policy

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -40,13 +40,13 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: plugin
       
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}


### PR DESCRIPTION
## Summary

Pins all GitHub Actions workflow steps to full commit SHAs to comply with the org's SHA-pinning policy.

## Test plan
- [ ] Verify CI workflows run successfully after the pin changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)